### PR TITLE
feat: add a filter to decorators

### DIFF
--- a/extension.js
+++ b/extension.js
@@ -63,6 +63,9 @@ function createGetterAndSetter(textPorperties)
         let words = p.split(" ").map(x => x.replace(/\r?\n/, ''));
         let type, attribute, Attribute = "";
         let create = false;
+
+        // filter decorators
+        words = words.filter(word => !word.startsWith('@'));
         
         // if words == ["private", "String", "name"];
         if (words.length > 2)


### PR DESCRIPTION
# Add a filter to decorators

In the current version of the extension selecting decorators generates wrong getters and setters. With this corretion the extension will be able to correctly generate getters and setters even when  there is decorators between the variables.

## Example

 Here is an example of how the extension work before and after this update:

**Before**:
![Before](https://user-images.githubusercontent.com/48259810/144057417-454991a7-da2d-4aca-8cd7-60aeab3589dc.png)

**After**:
![After](https://user-images.githubusercontent.com/48259810/144057538-0a8d5889-75da-406b-af9f-7acd0867bab9.png)

